### PR TITLE
fix(GraphQLConnector): separate headers and body when resolving with …

### DIFF
--- a/src/GraphQLConnector.js
+++ b/src/GraphQLConnector.js
@@ -82,13 +82,11 @@ export default class GraphQLConnector {
       const hasCache = this.enableCache && this.getCached(key, resolve, reject);
 
       this.request(this.getRequestConfig(uri))
-        .then(response => {
-          const data = options.resolveWithHeaders
-            ? { ...response.headers, ...response.body }
-            : response.body;
+        .then(({ headers, body, statusCode }) => {
+          const data = options.resolveWithHeaders ? { headers, body } : body;
 
           // If the data came through alright, cache it.
-          if (response.statusCode === 200) {
+          if (statusCode === 200) {
             this.addToCache(key, data);
           }
 

--- a/test/GraphQLConnector.test.js
+++ b/test/GraphQLConnector.test.js
@@ -185,8 +185,12 @@ describe('GraphQLConnector', () => {
         .getRequestData('https://example.com', { resolveWithHeaders: true })
         .then(result => {
           expect(result).toEqual({
-            'content-type': 'application/json',
-            test: 'body',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: {
+              test: 'body',
+            },
           });
           expect(tc.redis.setex).toHaveBeenCalled();
         });


### PR DESCRIPTION
…both

Slight addendum to that last one. This will be safe if the response comes back as anything other than an object.