### PR TITLE
feat: enable API level granularity for cache controls

### DIFF
--- a/src/cacheUtils.js
+++ b/src/cacheUtils.js
@@ -40,9 +40,8 @@ const addToCache = (connector, key, uri, options, response) => {
       'true',
     );
   }
-  const shortUri = connector.getShortUri(uri);
   connector.logger.info(
-    `caching response data for ${shortUri} for ${expiry} seconds`,
+    `caching response data for ${uri} for ${expiry} seconds`,
   );
   connector.redis.setex(key, expiry, JSON.stringify(response));
 };

--- a/src/cacheUtils.js
+++ b/src/cacheUtils.js
@@ -1,0 +1,93 @@
+const REFRESH_CACHE_PREFIX_KEY = 'REFRESH_CACHE_';
+
+const getCustomCacheOptions = (connector, options) => {
+  let expiry = connector.cacheExpiry;
+  let setCustomRefresh = false;
+  let setCache = true;
+  if (options.cacheExpiry === 0) {
+    setCache = false;
+  } else if (options.cacheExpiry > 0) {
+    expiry = options.cacheExpiry;
+  }
+  if (options.cacheRefresh > 0) {
+    setCustomRefresh = options.cacheRefresh;
+  }
+  return { expiry, setCustomRefresh, setCache };
+};
+
+/**
+ * Stores given data in the cache for a set amount of time.
+ * @param  {string} key      an MD5 hash of the request URI
+ * @param  {object} response the data to be cached
+ * @return {object}          the response, unchanged
+ */
+const addToCache = (connector, key, uri, options, response) => {
+  if (!connector.enableCache) {
+    return;
+  }
+  const { expiry, setCustomRefresh, setCache } = getCustomCacheOptions(
+    connector,
+    options,
+  );
+  if (setCache === false) {
+    return; //cache is set to 0, so do not store to cache
+  }
+  if (setCustomRefresh !== false) {
+    //Custom refresh is set to true, save a redix key that indicates while present we do not want to call the api and refresh cache
+    connector.redis.setex(
+      `${REFRESH_CACHE_PREFIX_KEY}${key}`,
+      setCustomRefresh,
+      'true',
+    );
+  }
+  const shortUri = connector.getShortUri(uri);
+  connector.logger.info(
+    `caching response data for ${shortUri} for ${expiry} seconds`,
+  );
+  connector.redis.setex(key, expiry, JSON.stringify(response));
+};
+
+/**
+ * Loads data from the cache, if available.
+ * @param  {string}   key       the cache identifier key
+ * @param  {function} successCB typically a Promise's `resolve` function
+ * @param  {function} errorCB   typically a Promise's `reject` function
+ * @return {boolean}            true if cached data was found, false otherwise
+ */
+const getCached = (connector, key, successCB, errorCB) => {
+  connector.redis.get(key, (error, data) => {
+    if (error) {
+      errorCB(error);
+    }
+
+    // If we have data, initiate a refetch in the background and return it.
+    if (data !== null) {
+      connector.logger.info('loading data from cache');
+
+      // The success callback will typically resolve a Promise.
+      successCB(JSON.parse(data));
+    } else {
+      successCB(null);
+    }
+  });
+};
+
+const isCacheEnabled = (connector, options) => {
+  if (!connector.redis || !connector.enableCache) {
+    return false;
+  }
+  if (options && options.cacheExpiry === 0) {
+    return false;
+  }
+  return true;
+};
+
+const refreshCache = (connector, uri, options, key) => {
+  connector.redis.get(`${REFRESH_CACHE_PREFIX_KEY}${key}`, (error, data) => {
+    if (data !== 'true') {
+      //Key expired, means it's time to refresh cache;
+      connector.makeRequest(uri, options, key);
+    }
+  });
+};
+export { addToCache, isCacheEnabled, getCached, refreshCache };

--- a/src/defaultLogger.js
+++ b/src/defaultLogger.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
+const time = () => `[${new Date().toISOString()}]`;
 export default {
-  info: msg => console.info(msg),
-  warn: msg => console.warn(msg),
-  error: msg => console.error(msg),
+  info: msg => console.info(time(), msg),
+  warn: msg => console.warn(time(), msg),
+  error: msg => console.error(time(), msg),
 };

--- a/test/GraphQLConnector.test.js
+++ b/test/GraphQLConnector.test.js
@@ -76,6 +76,10 @@ describe('GraphQLConnector', () => {
 
       tc.redis = mockRedis.getClient();
 
+      tc.redis.get = jest.fn((key, cb) => {
+        cb(null, '{"test":"body"}');
+      });
+
       return tc.getRequestData('https://example.com').then(result => {
         expect(result).toEqual({ test: 'body' });
         expect(tc.redis.setex).toHaveBeenCalled();
@@ -147,6 +151,7 @@ describe('GraphQLConnector', () => {
         }),
       );
 
+      tc.getCached = jest.fn((uri, resolve) => resolve());
       tc.addToCache = jest.fn();
 
       const result = await tc.getRequestData('https://example.com/');
@@ -161,6 +166,7 @@ describe('GraphQLConnector', () => {
       const tc = new TestConnector();
 
       tc.request = () => Promise.reject(Error('test error'));
+      tc.getCached = jest.fn((uri, resolve) => resolve());
 
       return tc.getRequestData('https://example.com/rejectme').catch(error => {
         expect(error).toHaveProperty('isBoom', true);
@@ -173,13 +179,14 @@ describe('GraphQLConnector', () => {
           expect.stringMatching(/test error/),
         );
       });
-    });
+    });   
 
     it('resolves with response headers if specified', async () => {
       expect.assertions(2);
       const tc = new TestConnector();
 
       tc.redis = mockRedis.getClient();
+      tc.getCached = jest.fn((uri, resolve) => resolve());
 
       return tc
         .getRequestData('https://example.com', { resolveWithHeaders: true })
@@ -193,6 +200,127 @@ describe('GraphQLConnector', () => {
             },
           });
           expect(tc.redis.setex).toHaveBeenCalled();
+        });
+    });
+
+    it('does not cache if specified in options', async () => {
+      expect.assertions(3);
+      const tc = new TestConnector();
+
+      tc.redis = mockRedis.getClient();
+
+      return tc
+        .getRequestData('https://example.com', { cacheExpiry: 0 })
+        .then(result => {
+          expect(result).toEqual({ test: 'body' });
+          expect(tc.redis.get).not.toHaveBeenCalled();
+          expect(tc.redis.setex).not.toHaveBeenCalled();
+        });
+    });
+
+    it('Caches for a longer time if passed in custom cache time in options', async () => {
+      expect.assertions(4);
+      const tc = new TestConnector();
+
+      tc.redis = mockRedis.getClient();
+      tc.redis.get = jest.fn((key, cb) => {
+        cb(null, '{"test":"body"}');
+      });
+
+      return tc
+        .getRequestData('https://example.com', { cacheExpiry: 36000 })
+        .then(result => {
+          expect(result).toEqual({ test: 'body' });
+          expect(tc.redis.get).toHaveBeenCalled();
+          expect(tc.redis.setex.mock.calls[0][1]).toEqual(36000);
+          expect(tc.redis.setex.mock.calls[0][2]).toEqual('{"test":"body"}');
+        });
+    });
+
+    it('Sets a second key in redis to keep track of when not to call API call if option is passed in', async () => {
+      expect.assertions(7);
+      const tc = new TestConnector();
+
+      tc.redis = mockRedis.getClient();
+      tc.redis.get = jest.fn((key, cb) => {
+        cb(null, null);
+      });
+
+      return tc
+        .getRequestData('https://example.com', {
+          cacheRefresh: 1800,
+          cacheExpiry: 36000,
+        })
+        .then(result => {
+          expect(result).toEqual({ test: 'body' });
+          expect(tc.redis.get).toHaveBeenCalled();
+          const redisKey = tc.redis.setex.mock.calls[1][0];
+          expect(tc.redis.setex.mock.calls[0][0]).toEqual(
+            `REFRESH_CACHE_${redisKey}`,
+          );
+          expect(tc.redis.setex.mock.calls[0][1]).toEqual(1800);
+          expect(tc.redis.setex.mock.calls[0][2]).toEqual('true');
+          expect(tc.redis.setex.mock.calls[1][1]).toEqual(36000);
+          expect(tc.redis.setex.mock.calls[1][2]).toEqual('{"test":"body"}');
+        });
+    });
+
+    it('checks if refresh cache is needed, and if key is still set, do not make request', async () => {
+      expect.assertions(4);
+      const tc = new TestConnector();
+
+      tc.makeRequest = jest.fn();
+      tc.redis = mockRedis.getClient();
+      tc.redis.get = jest.fn((key, cb) => {
+        if(key.indexOf('REFRESH') !== -1) {
+          cb(null, 'true');
+        } else {
+          cb(null, '{"test":"body"}');
+        }
+      });
+
+      return tc
+        .getRequestData('https://example.com', {
+          cacheRefresh: 1800,
+          cacheExpiry: 36000,
+        })
+        .then(result => {
+          expect(result).toEqual({ test: 'body' });
+          expect(tc.makeRequest).not.toHaveBeenCalled();
+          expect(tc.redis.get).toHaveBeenCalledTimes(2);
+          expect(tc.redis.setex).not.toHaveBeenCalled();
+        });
+    });
+
+    it('checks if refresh cache is needed, and if key is not set, make request', async () => {
+      expect.assertions(7);
+      const tc = new TestConnector();
+
+      tc.redis = mockRedis.getClient();
+      tc.redis.get = jest.fn((key, cb) => {
+        if(key.indexOf('REFRESH') !== -1) {
+          cb(null, null);
+        } else {
+          cb(null, '{"test":"body"}');
+        }
+      });
+
+      return tc
+        .getRequestData('https://example.com', {
+          cacheRefresh: 1800,
+          cacheExpiry: 36000,
+        })
+        .then(result => {
+          expect(result).toEqual({ test: 'body' });
+          expect(tc.redis.get).toHaveBeenCalledTimes(2);
+          const redisKey = tc.redis.setex.mock.calls[1][0];
+          expect(tc.redis.setex.mock.calls[0][0]).toEqual(
+            `REFRESH_CACHE_${redisKey}`,
+          );
+          expect(tc.redis.setex.mock.calls[0][1]).toEqual(1800);
+          expect(tc.redis.setex.mock.calls[0][2]).toEqual('true');
+          expect(tc.redis.setex.mock.calls[1][1]).toEqual(36000);
+          expect(tc.redis.setex.mock.calls[1][2]).toEqual('{"test":"body"}');
         });
     });
   });

--- a/test/defaultLogger.test.js
+++ b/test/defaultLogger.test.js
@@ -2,6 +2,7 @@
 import defaultLogger from '../src/defaultLogger';
 
 describe('defaultLogger', () => {
+  //matches timestamp
   const stringMatches = expect.stringMatching(/[.*]/);
   it('uses the console for info logging', () => {
     console.info = jest.fn();

--- a/test/defaultLogger.test.js
+++ b/test/defaultLogger.test.js
@@ -2,12 +2,13 @@
 import defaultLogger from '../src/defaultLogger';
 
 describe('defaultLogger', () => {
+  const stringMatches = expect.stringMatching(/[.*]/);
   it('uses the console for info logging', () => {
     console.info = jest.fn();
 
     defaultLogger.info('info test');
 
-    expect(console.info).toHaveBeenCalledWith('info test');
+    expect(console.info).toHaveBeenCalledWith(stringMatches, 'info test');
   });
 
   it('uses the console for warn logging', () => {
@@ -15,7 +16,7 @@ describe('defaultLogger', () => {
 
     defaultLogger.warn('warn test');
 
-    expect(console.warn).toHaveBeenCalledWith('warn test');
+    expect(console.warn).toHaveBeenCalledWith(stringMatches, 'warn test');
   });
 
   it('uses the console for error logging', () => {
@@ -23,6 +24,6 @@ describe('defaultLogger', () => {
 
     defaultLogger.error('error test');
 
-    expect(console.error).toHaveBeenCalledWith('error test');
+    expect(console.error).toHaveBeenCalledWith(stringMatches, 'error test');
   });
 });


### PR DESCRIPTION
Currently, caching has some limitations:

1) Caching is all or nothing, you either don't enable caching, or every API call is cached
2) There is a single configurable expiration time for the cache for all APIs.
3) The API call is made every time and refreshes the cache for every single time the call is made. This can be wasteful in certain cases.

Solution i've come up with is to create a custom configuration object on a per-api level that allows the following:
- If an API is not on the list, it will use the default caching time. Same behavior as before
- If an API is on the list, you can specify
    a. how long to keep the cache, as this data might rarely change and you want to cache for hours, not minutes.
    b. specify no cache at all, for things like say getting the current temperature or status, volatile data that changes all the time and there is no value in caching it.
    c. specify how often to refresh the cache. If not specified, it makes the API call and refreshes every time (same behavior as before). However, if specified it will skip the API call if within the threshold, return the cache and exit.

for example say the cache is 4 hours, and the refreshCache value is 1 hour, then

    first api call detects no cache exists, so fetches the value from API source, return the value, and stores in the cache
    2nd API call comes in 30 minutes later. the hour hasn't gone by yet, so it returns the value from the cache and does not call the API.
    3rd API call comes in 2 hours later. We still have the cache, so return the cache, but make the API call and store the new value in the cache, since 2 hours is after our 1 hour threshold. 1 hour threshold starts over at this point.
    4th API call comes in 6 hours later, back to (1).


- i've also changed the logging to include timestamps and URIs, which is useful when debugging performance