### PR TITLE
fix: save headers before making a request, to avoid collisions with many requests

### DIFF
--- a/test/GraphQLConnector.test.js
+++ b/test/GraphQLConnector.test.js
@@ -106,6 +106,26 @@ describe('GraphQLConnector', () => {
       });
     });
 
+    it('resolves with body of request if cache is bad', async () => {
+      expect.assertions(2);
+
+      const tc = new TestConnector();
+
+      tc.redis = mockRedis.getClient();
+
+      // Mock the Redis get method to return cached data.
+      tc.redis.get = jest.fn((key, cb) => {
+        cb(null, '{"test":"truncated');
+      });
+
+      return tc.getRequestData('https://example.com').then(result => {
+        expect(result).toEqual({ test: 'body' });
+
+        // It should still make the request in the background, though.
+        expect(tc.request).toHaveBeenCalled();
+      });
+    });
+
     it('rejects if there is an error with Redis', async () => {
       expect.assertions(1);
 


### PR DESCRIPTION
There's a scenario where 2 requests come in, each relies on saving the authentication headers in the connector, each time overwriting the previous request's headers. In this scenario, when request 1 comes in, saves the headeres, it hits redis to see if cache is there. Since that's an async call and we live in a single-threaded runtime, request 2 will execute and overwrite the headers as usual and execute all the way through. Request 1's callback from redis returns, and gets the headers saved in the connector, which are from request 2 !!!!! , and call is made with wrong Auth.

This is remediated simply by saving the headers in local scope before calling redis, which guarantees that if the headers from connector get overwritten, no big deal, we saved them before that happens and we have the right headers.

Also fixed a scenario where a bad cache can cripple an operation, by adding a safeguard and forcing a refetch in that case.